### PR TITLE
Tiny optimisation in ban pubsub

### DIFF
--- a/pubSubHandlers/banHandler.py
+++ b/pubSubHandlers/banHandler.py
@@ -13,7 +13,5 @@ class handler(generalPubSubHandler.generalPubSubHandler):
 			return
 		targetToken = glob.tokens.getTokenFromUserID(userID)
 		if targetToken is not None:
-			#targetToken.privileges = userUtils.getPrivileges(userID)
-			targetToken.refresh_privs()
 			targetToken.checkBanned()
 			targetToken.checkRestricted()


### PR DESCRIPTION
refresh_privs is called in checkRestricted, so there's no need to call it before hand. with the way it is rn, checking the old restriction status vs the new one is also broke as it would've already updated