### PR TITLE
Improve UX when logging in with outdated clients

### DIFF
--- a/events/loginEvent.py
+++ b/events/loginEvent.py
@@ -337,13 +337,13 @@ def handle(tornadoRequest):
         elif osuVersion[0] != "b":
             glob.tokens.deleteToken(userID)
             raise exceptions.haxException()
-        
+
         # Special case for old fallback client
         elif osuVersion == "20160403.6":
             glob.tokens.deleteToken(userID)
             responseData += FALLBACK_NOTIF
             raise exceptions.loginFailedException
-        
+
         # Misc outdated client check
         elif int(osuVersion[1:5]) < MINIMUM_CLIENT_YEAR:
             glob.tokens.deleteToken(userID)


### PR DESCRIPTION
Currently, very little verification on the user's client version is done. This means that it is very trivial for a user to unintentionally log into the server with an older client (with fallback being a common example). This would prompt them to be caught by the server's anticheat later on, causing a restriction. This change will ensure that they are notified of this prior to login.