### PR TITLE
Implement the ban log system into pep.py

### DIFF
--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -34,6 +34,7 @@ from helpers import chatHelper as chat
 from helpers import systemHelper
 from helpers.status_helper import UserStatus
 from helpers.user_helper import username_safe
+from helpers.user_helper import restrict_with_log
 from logger import log
 from objects import fokabot
 from objects import glob

--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -33,8 +33,8 @@ from constants import slotStatuses
 from helpers import chatHelper as chat
 from helpers import systemHelper
 from helpers.status_helper import UserStatus
-from helpers.user_helper import username_safe
 from helpers.user_helper import restrict_with_log
+from helpers.user_helper import username_safe
 from logger import log
 from objects import fokabot
 from objects import glob

--- a/constants/packetIDs.py
+++ b/constants/packetIDs.py
@@ -57,6 +57,7 @@ client_channelJoin = 63
 server_channel_join_success = 64
 server_channelInfo = 65
 server_channelKicked = 66
+client_beatmapInfoRequest = 68
 client_matchTransferHost = 70
 server_supporterGMT = 71
 server_friendsList = 72

--- a/events/beatmapInfoRequest.py
+++ b/events/beatmapInfoRequest.py
@@ -1,0 +1,11 @@
+from objects.osuToken import UserToken
+from helpers.user_helper import restrict_with_log
+
+def handle(token: UserToken, _) -> None:
+    restrict_with_log(
+        token.userID,
+        "Outdated client bypassing login gate",
+        "The user has send a beatmap request packet, which has been removed "
+        "since ~2020. This means that they likely have a client with a version "
+        "changer to bypass the login gate. (bancho gate)"
+    )

--- a/events/beatmapInfoRequest.py
+++ b/events/beatmapInfoRequest.py
@@ -1,5 +1,8 @@
-from objects.osuToken import UserToken
+from __future__ import annotations
+
 from helpers.user_helper import restrict_with_log
+from objects.osuToken import UserToken
+
 
 def handle(token: UserToken, _) -> None:
     restrict_with_log(
@@ -7,5 +10,5 @@ def handle(token: UserToken, _) -> None:
         "Outdated client bypassing login gate",
         "The user has send a beatmap request packet, which has been removed "
         "since ~2020. This means that they likely have a client with a version "
-        "changer to bypass the login gate. (bancho gate)"
+        "changer to bypass the login gate. (bancho gate)",
     )

--- a/events/loginEvent.py
+++ b/events/loginEvent.py
@@ -462,7 +462,6 @@ def handle(tornadoRequest):
         # Invalid POST data
         # (we don't use enqueue because we don't have a token since login has failed)
         responseData += serverPackets.login_failed()
-        responseData += serverPackets.notification("I have eyes y'know?")
     except exceptions.loginBannedException:
         # Login banned error packet
         responseData += serverPackets.login_banned()

--- a/events/loginEvent.py
+++ b/events/loginEvent.py
@@ -15,10 +15,11 @@ from helpers import chatHelper as chat
 from helpers import geo_helper
 from helpers.geo_helper import get_full
 from helpers.realistik_stuff import Timer
-from helpers.user_helper import get_country, restrict_with_log
+from helpers.user_helper import get_country
+from helpers.user_helper import insert_ban_log
+from helpers.user_helper import restrict_with_log
 from helpers.user_helper import set_country
 from helpers.user_helper import verify_password
-from helpers.user_helper import insert_ban_log
 from logger import log
 from objects import glob
 
@@ -282,7 +283,7 @@ def handle(tornadoRequest):
                     "Attempted login with Ainu Client 2020",
                     "The user has attempted to log in with a the Ainu 2020 client. "
                     "This is a known cheating client. The user has been detected through "
-                    "the ainu header sent on login. (login gate)."
+                    "the ainu header sent on login. (login gate).",
                 )
                 raise exceptions.loginCheatClientsException()
         # Ainu Client 2019

--- a/handlers/mainHandler.pyx
+++ b/handlers/mainHandler.pyx
@@ -54,6 +54,7 @@ from events import userStatsRequestEvent
 from events import tournamentMatchInfoRequestEvent
 from events import tournamentJoinMatchChannelEvent
 from events import tournamentLeaveMatchChannelEvent
+from events import beatmapInfoRequest
 from helpers import packetHelper
 from objects import glob
 
@@ -114,6 +115,7 @@ eventHandler = {
 	packetIDs.client_tournamentMatchInfoRequest: (tournamentMatchInfoRequestEvent),
 	packetIDs.client_tournamentJoinMatchChannel: (tournamentJoinMatchChannelEvent),
 	packetIDs.client_tournamentLeaveMatchChannel: (tournamentLeaveMatchChannelEvent),
+	packetIDs.client_beatmapInfoRequest: (beatmapInfoRequest),
 }
 
 

--- a/helpers/user_helper.py
+++ b/helpers/user_helper.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import bcrypt
+from common.constants import privileges
 
 from objects import glob
-from common.constants import privileges
 
 
 def username_safe(s: str) -> str:
@@ -71,12 +71,13 @@ def set_country(user_id: int, country_code: str) -> None:
         (country_code, user_id),
     )
 
+
 def insert_ban_log(
     user_id: int,
     summary: str,
     detail: str,
     prefix: bool = True,
-    from_id: int = 999, # TODO: Don't hardcode the bot id.
+    from_id: int = 999,  # TODO: Don't hardcode the bot id.
 ) -> None:
     """Inserts a ban log for a user into the database.
 
@@ -89,10 +90,10 @@ def insert_ban_log(
         from_id (int, optional): The ID of the user who banned the user.
             Defaults to 999 (the bot).
     """
-    
+
     if prefix:
         detail = "pep.py Autoban: " + detail
-    
+
     glob.db.execute(
         "INSERT INTO ban_logs (from_id, to_id, summary, detail) VALUES (%s, %s, %s, %s)",
         (
@@ -100,8 +101,9 @@ def insert_ban_log(
             user_id,
             summary,
             detail,
-        )
+        ),
     )
+
 
 def restrict_with_log(
     user_id: int,
@@ -121,10 +123,10 @@ def restrict_with_log(
         from_id (int, optional): The ID of the user who banned the user.
             Defaults to 999 (the bot).
     """
-    
+
     glob.db.execute(
         f"UPDATE users SET privileges = privileges & ~{privileges.USER_PUBLIC} WHERE id = %s LIMIT 1",
-        (user_id,)
+        (user_id,),
     )
-    
+
     insert_ban_log(user_id, summary, detail, prefix, from_id)


### PR DESCRIPTION
This PR implements the USSR ban log system into pep.py, allowing for staff to more easily see the ban reasons for the server.