### PR TITLE
Implement the ban reason system into pep.py

### DIFF
--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -47,7 +47,9 @@ commands = {}
 Command = namedtuple("Command", ["trigger", "callback", "syntax", "privileges"])
 
 
-def registerCommand(trigger: str, syntax: Optional[str] = None, privs: Optional[int] = None):
+def registerCommand(
+    trigger: str, syntax: Optional[str] = None, privs: Optional[int] = None,
+):
     """A decorator to set commands into list."""
     global commands
 

--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -11,7 +11,6 @@ from collections import namedtuple
 from datetime import datetime
 from datetime import timedelta
 from typing import Callable
-from helpers import user_helper
 
 import osupyparser
 import requests
@@ -33,6 +32,7 @@ from constants import serverPackets
 from constants import slotStatuses
 from helpers import chatHelper as chat
 from helpers import systemHelper
+from helpers import user_helper
 from helpers.status_helper import UserStatus
 from helpers.user_helper import restrict_with_log
 from helpers.user_helper import username_safe
@@ -599,6 +599,8 @@ def unban(fro, chan, message):
 
 
 REASON_REGEX = re.compile('(".+") (".+")')
+
+
 @registerCommand(
     trigger="!restrict",
     syntax='<target> "summary" "detail"',
@@ -619,7 +621,6 @@ def restrict(fro, chan, message):
     userID = userUtils.getID(fro)
     if not targetUserID:
         return f"Could not find the user '{target}' on the server."
-    
 
     user_helper.restrict_with_log(
         targetUserID,

--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from datetime import datetime
 from datetime import timedelta
 from typing import Callable
+from typing import Optional
 
 import osupyparser
 import requests
@@ -46,7 +47,7 @@ commands = {}
 Command = namedtuple("Command", ["trigger", "callback", "syntax", "privileges"])
 
 
-def registerCommand(trigger: str, syntax: str = None, privs: privileges = None):
+def registerCommand(trigger: str, syntax: Optional[str] = None, privs: Optional[int] = None):
     """A decorator to set commands into list."""
     global commands
 
@@ -125,7 +126,7 @@ def mirrorMessage(beatmapID):
     )
 
 
-def restartShutdown(restart):
+def restartShutdown(restart: bool):
     """Restart (if restart = True) or shutdown (if restart = False) pep.py safely"""
     msg = "We are performing some maintenance. Bancho will {} in 5 seconds. Thank you for your patience.".format(
         "restart" if restart else "shutdown",
@@ -308,7 +309,7 @@ def editMap(fro: str, chan: str, message: list[str]) -> str:
             url=f"https://ussr.pl/beatmaps/{token.tillerino[0]}",
             icon_url=f"https://a.ussr.pl/{token.userID}",
         )
-        embed.set_footer(text="via RealistikPanel!")
+        embed.set_footer(text="via pep.py!")
         embed.set_image(
             url=f"https://assets.ppy.sh/beatmaps/{res['beatmapset_id']}/covers/cover.jpg",
         )

--- a/constants/fokabotCommands.py
+++ b/constants/fokabotCommands.py
@@ -634,7 +634,7 @@ def restrict(fro, chan, message):
     if targetToken is not None:
         targetToken.notify_restricted()
 
-    return f"{target} has been successfully restricted for "
+    return f"{target} has been successfully restricted for '{summary}'"
 
 
 @registerCommand(


### PR DESCRIPTION
This PR reworks the restrict command, allowing staff to explicitly state their reasoning for a ban.